### PR TITLE
make it possible to either augment objects or to use prototypical inheritance

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -1,31 +1,66 @@
-<script src="../src/EventDispatcher.js"></script>
-<script>
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf8" />
+    </head>
+    <body>
+        <script src="../src/EventDispatcher.js"></script>
+        <script>
 
-	// Adding events to custom object
+            // Adding events to custom object
 
-	var Car = function () {
+            var Car = function () {
 
-		this.start = function () {
+                EventDispatcher.call( this );
 
-			this.dispatchEvent( { type: 'start', message: 'vroom vroom!' } );
+                this.start = function () {
 
-		};
+                    this.dispatchEvent( { type: 'start', message: 'vroom vroom!' } );
 
-	};
+                };
 
-	Car.prototype = Object.create( EventDispatcher.prototype );
+            };
 
 
-	// Using events
+            // Using the EventDispatcher prototype
 
-	var car = new Car();
+            var PrototypicalCar = function() {
 
-	car.addEventListener( 'start', function ( event ) {
+                this.start = function() {
 
-		alert( event.message );
+                    this.dispatchEvent( { type: 'start', message: 'prototypical vrooom!' } );
 
-	} );
+                };
 
-	car.start();
+            };
 
-</script>
+            PrototypicalCar.prototype = Object.create( EventDispatcher.prototype );
+
+
+            // Using events
+
+            var car = new Car();
+
+            car.addEventListener( 'start', function ( event ) {
+
+                console.log( event.message );
+
+            } );
+
+            car.start();
+
+
+
+            var prototypicalCar = new PrototypicalCar();
+
+            prototypicalCar.addEventListener( 'start', function( event ) {
+
+                console.log( event.message );
+
+            } );
+
+            prototypicalCar.start();
+
+        </script>
+    </body>
+</html>

--- a/src/EventDispatcher.js
+++ b/src/EventDispatcher.js
@@ -2,7 +2,14 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
-var EventDispatcher = function () {}
+var EventDispatcher = function () {
+
+	this.addEventListener = EventDispatcher.prototype.addEventListener;
+	this.hasEventListener = EventDispatcher.prototype.hasEventListener;
+	this.removeEventListener = EventDispatcher.prototype.removeEventListener;
+	this.dispatchEvent = EventDispatcher.prototype.dispatchEvent;
+
+};
 
 EventDispatcher.prototype = {
 


### PR DESCRIPTION
This version allows you to add event dispatching abilities with the older EventDispatcher.call(this) call, or to use the EventDispatcher.prototype as prototype for your object, as in the latest version of the library.

I've changed the example to demonstrate both styles.
