### PR TITLE
Fixes #11: Add ability to store a reference to and added event for easy event removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ eventdispatcher.js
 	} );
 
 	car.start();
+	
+	// Optional way to simply remove the event using the reference to the handler.
+	starter();
 
 </script>
 ```

--- a/examples/index.html
+++ b/examples/index.html
@@ -20,12 +20,16 @@
 
 	var car = new Car();
 
-	car.addEventListener( 'start', function ( event ) {
+	var starter = car.addEventListener( 'start', function ( event ) {
 
 		alert( event.message );
 
 	} );
 
 	car.start();
+	
+	// Optional way to simply remove the event using the reference to the handler.
+	starter();
+	
 
 </script>

--- a/src/EventDispatcher.js
+++ b/src/EventDispatcher.js
@@ -21,7 +21,8 @@ EventDispatcher.prototype = {
 
 		if ( this._listeners === undefined ) this._listeners = {};
 
-		var listeners = this._listeners;
+		var listeners = this._listeners,
+			_this = this;
 
 		if ( listeners[ type ] === undefined ) {
 
@@ -33,6 +34,10 @@ EventDispatcher.prototype = {
 
 			listeners[ type ].push( listener );
 
+		}
+		
+		return function () {
+			_this.removeEventListener(type, listener);
 		}
 
 	},


### PR DESCRIPTION
Returning a function from calls to addEventListener that will be able to call removeEventListener with a reference to the original handler that was passed in.
