### PR TITLE
return listener in addEventListener

### DIFF
--- a/src/EventDispatcher.js
+++ b/src/EventDispatcher.js
@@ -35,6 +35,7 @@ EventDispatcher.prototype = {
 
 		}
 
+		return listener;
 	},
 
 	hasEventListener: function ( type, listener ) {


### PR DESCRIPTION
this change is fully backwards-compatible. we used it to automatically replace function with the call to addEventListener, but people might simply use it for chain calls / shorter code.
