### PR TITLE
Enforce dispatcher to not dispatch event after it was removed.

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -28,4 +28,16 @@
 
 	car.start();
 
+	car.removeAllEventListeners();
+
+	car.start();
+
+	car.addEventListener( 'start', function ( event ) {
+
+		alert( event.message + " again!" );
+
+	} );
+
+	car.start();
+	
 </script>

--- a/src/EventDispatcher.js
+++ b/src/EventDispatcher.js
@@ -14,12 +14,19 @@ EventDispatcher.prototype = {
 		object.hasEventListener = EventDispatcher.prototype.hasEventListener;
 		object.removeEventListener = EventDispatcher.prototype.removeEventListener;
 		object.dispatchEvent = EventDispatcher.prototype.dispatchEvent;
+		object.removeAllEventListeners = EventDispatcher.prototype.removeAllEventListeners;
 
 	},
 
 	addEventListener: function ( type, listener ) {
 
-		if ( this._listeners === undefined ) this._listeners = {};
+		if ( this._listeners === undefined ) {
+			this._listeners = {};
+			// denotes number of distict events dispatched at the moment. Used in remove all events.
+			this._eventDispatcherLock = 0;
+			// per-event lock.
+			this._eventDispatcherLocks = {};
+		}
 
 		var listeners = this._listeners;
 
@@ -66,7 +73,7 @@ EventDispatcher.prototype = {
 
 			if ( index !== - 1 ) {
 
-				listenerArray.splice( index, 1 );
+				listenerArray[index] = null;
 
 			}
 
@@ -75,33 +82,66 @@ EventDispatcher.prototype = {
 	},
 
 	dispatchEvent: function ( event ) {
-			
 		if ( this._listeners === undefined ) return;
 
 		var listeners = this._listeners;
+
+		if ( !listeners[ event.type ] || !listeners[ event.type ].length )
+			return;
+
 		var listenerArray = listeners[ event.type ];
 
-		if ( listenerArray !== undefined ) {
+		event.target = this;
 
-			event.target = this;
+		if(this._eventDispatcherLocks[event.type]++ === 0)
+			++this._eventDispatcherLock;
 
-			var array = [];
-			var length = listenerArray.length;
+		var currentIndex = 0;
 
-			for ( var i = 0; i < length; i ++ ) {
-
-				array[ i ] = listenerArray[ i ];
-
+		for(var i = 0, l = listenerArray.length; i < l; i++) {
+			if(listenerArray[i]) {
+				listenerArray[i].call(this, event);
+				if(currentIndex !== i) {
+					listenerArray[currentIndex] = listenerArray[i];
+					listenerArray[i] = null;
+				}
+				++currentIndex;
 			}
-
-			for ( var i = 0; i < length; i ++ ) {
-
-				array[ i ].call( this, event );
-
-			}
-
 		}
 
-	}
+		if(--this._eventDispatcherLocks[event.type] === 0) {
+			if(currentIndex !== i) {
+				var numObjects = listenerArray.length;
+				while(i < numObjects)
+					listenerArray[currentIndex++] = listenerArray[i++];
+				listenerArray.length = currentIndex;
+			}
+		}
+	},
 
+	removeAllEventListeners: function(type) {
+		var a, i, l;
+		if(undefined === this._listeners) return;
+		var listeners = this._listeners;
+		var locks = this._eventDispatcherLocks;
+		if(type) {
+			a = listeners[type];
+			if(a) {
+				if(locks[type] === 0) a.length = 0;
+				else for(i = 0, l = a.length; i < l; i++) a[i] = null; // we cannot just truncate if there are emits
+			}
+		} else {
+			if(this._eventDispatcherLock === 0) {
+				this._listeners = {};
+				this._eventDispatcherLocks = {};
+			} else { // if there are any events dispatching in the moment - this action becomes more expensive...
+				for(var typeName in listeners) {
+					if(!listeners.hasOwnProperty(typeName)) continue;
+					a = listeners[typeName];
+					if(locks[typeName] === 0) a.length = 0;
+					else for(i = 0, l = a.length; i < l; i++) a[i] = null;
+				}
+			}
+		}
+	}
 };


### PR DESCRIPTION
Remove all event listeners functionality.

I see you copy all the events each time you emit an event. I hope my approach (which originally comes from starling implementation of juggler - their animation manager) can save some time and memory :)

Also, some times, in one event handler, we remove other event handler, and it's disappointing, when removed event handler is called. making event handlers null on remove, and skip them in event dispatching code allows this to happen.

Hope you gonna like it :)
